### PR TITLE
fix(circle): Update deprecated circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:


### PR DESCRIPTION
Circle CI will not deploy the latest update to design tokens because we are using a legacy convenience image (see help[ here](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)) 

I am hoping that updating this to match what was in the linked page will allow us to build to circle and release once again