### PR TITLE
followup: update deprecated circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: cimg/android:api-30
+      - image: cimg/android:2023.08.1
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:


### PR DESCRIPTION
I thought I could just change the first part but didn't realize there wasn't a direct equivalent tag. You can see the actual accepted versions [here](https://circleci.com/developer/images/image/cimg/android#image-name). I went with one that did not add node, ndk, or browser since I don't think we need any of those 