### PR TITLE
followup: update deprecated circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: cimg/android:2023.08.1
+      - image: cimg/android:2023.06.1
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: cimg/android:api-30
+      - image: cimg/android:2023.08.1
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:


### PR DESCRIPTION
The last version failed circleci tests. After trying to update ruby and json locally instead, I thought I would try to decrease the version in the hopes that this would resolve the problem.