### PR TITLE
fix: Revert back to using cimg and update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2023.11.1
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:


### PR DESCRIPTION
It seems like `circleci/` is a deprecated image, and that the issue may have been unrelated from that anyway, so I am reverting it back and updating to a newer version. Also I need to trigger a version update so circle ci can build because re running gives an error since we need a new tag.