### PR TITLE
fix: Fix circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2023.11.1
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+.PHONY: setup download-ruby-dependencies
 create-release:
 	echo '"bundle exec fastlane android create_new_release"' | xargs -L 1 -P 2 bash -c
+
+setup:
+	sudo gem install bundler && bundle install
 
 download-ruby-dependencies:
 	bundle check || bundle update && bundle install --path vendor/bundle


### PR DESCRIPTION
I am still getting [errors while trying to build a new release ](https://app.circleci.com/pipelines/github/TodayTix/androidDesignTokens/234/workflows/1680aed2-d849-4b4d-92a4-aa656e55be2c/jobs/130).

Doing some research and comparing with our android code, I am adding
```
setup:
	sudo gem install bundler && bundle install
```
to ensure we have permission and can install the bundler as a recommendation from [this documentation](http://docs.fastlane.tools/getting-started/android/setup/#getting-started-with-fastlane-for-android)

I added the `.PHONY: setup download-ruby-dependencies` line because that is what we have in android, and [it looks like it is used to override these steps](https://dev.to/alexandrunastase/whats-the-meaning-of-phony-in-a-makefile-406k#:~:text=PHONY%20actually%20do%3F-,.,file%20that%20matches%20its%20name.). Since I could not find us directly running `make setup` in our android or androidDesignToken code, I assume that it is probably automatically ran, so I am hoping `.PHONY` will update it.