### PR TITLE
fix: revert to deprecated circleimage to troubleshoot github token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,4 @@ workflows:
             branches:
               only:
                 - main
+                - francesca/fix/revert-to-deprecated-circleimage-to-troubleshoot-github-token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ version: 2.1
 jobs:
   create-new-release:
     docker:
-      - image: cimg/android:2023.11.1
+      - image: circleci/android:api-30
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,4 +53,3 @@ workflows:
             branches:
               only:
                 - main
-                - francesca/fix/revert-to-deprecated-circleimage-to-troubleshoot-github-token

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
-.PHONY: setup download-ruby-dependencies
 create-release:
 	echo '"bundle exec fastlane android create_new_release"' | xargs -L 1 -P 2 bash -c
-
-setup:
-	sudo gem install bundler && bundle install
 
 download-ruby-dependencies:
 	bundle check || bundle update && bundle install --path vendor/bundle

--- a/designTokens/build.gradle
+++ b/designTokens/build.gradle
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 32
-        version "1.52.0"
+        version "1.53.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
there are issues with permissions when upgrading to cimage. I am reverting back so I can troubleshoot the other issue which was related to the github api access token.